### PR TITLE
FHIR stratifier for a Custodian

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>common-ldmclient</artifactId>
-    <version>6.0.0</version>
+    <version>6.0.1</version>
 
     <name>Samply Common LDMClient</name>
     <description>Samply Common LDM Client is an abstract library for the communication with Local Datamanagement systems.</description>

--- a/src/main/resources/de/samply/common/ldmclient/measure-specimen-stub.json
+++ b/src/main/resources/de/samply/common/ldmclient/measure-specimen-stub.json
@@ -46,6 +46,15 @@
             "language": "text/cql",
             "expression": "SampleMaterialTypeCategory"
           }
+        },
+        {
+          "code": {
+            "text": "Custodian"
+          },
+          "criteria": {
+            "language": "text/cql",
+            "expression": "Custodian"
+          }
         }
       ]
     }


### PR DESCRIPTION
Modified fhir stub for specimen to include a custodian reference, to use it in production we need to push it Maven repository

Is the new version number okay?
